### PR TITLE
Add missing CHANGELOG item for 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,8 @@
 ## v1.0
 
 Initial release.
-This release consists of the same middleware that was previously bundled with Faraday but removed in Faraday v2.0.
+This release consists of the same middleware that was previously bundled with Faraday but removed in Faraday v2.0, plus:
+
+### Fixed
+
+*  Retry middleware `retry_block` is not called if retry will not happen due to `max_interval`, https://github.com/lostisland/faraday/pull/1350


### PR DESCRIPTION
This was a change from last release of faraday when it included this middleware, so should be mentioned?
