### PR TITLE
README: update link to the RateLimit RFC

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ retry_options = {
 
 Some APIs, like the [Slack API](https://api.slack.com/docs/rate-limits), will inform you when you reach their API limits by replying with a response status code of `429`
 and a response header of `Retry-After` containing a time in seconds. You should then only retry querying after the amount of time provided by the `Retry-After` header,
-otherwise you won't get a response. Other APIs communicate their rate limits via the [RateLimit-xxx](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html#rfc.section.3.3) headers
+otherwise you won't get a response. Other APIs communicate their rate limits via the [RateLimit-xxx](https://www.ietf.org/archive/id/draft-ietf-httpapi-ratelimit-headers-05.html#name-providing-ratelimit-fields) headers
 where `RateLimit-Reset` behaves similarly to the `Retry-After`.
 
 You can automatically handle both headers and have Faraday pause and retry for the right amount of time by including the `429` status code in the retry statuses list:


### PR DESCRIPTION
The RFC has moved, due to moving onwards in its process, so the URL has changed.

This updates the link to reflect the latest.