### PR TITLE
style: disable Metrics/ClassLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ AllCops:
   SuggestExtensions: false
   NewCops: enable
 
+Metrics/ClassLength:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - spec/**/*.rb


### PR DESCRIPTION
In #13, the build failed due Metrics/ClassLength complaining about adding one or two lines to the one class which has the implementation (basically all of it).

This PR removes that check.