### PR TITLE
Update docs reference to RaiseError middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,4 +177,4 @@ Bug reports and pull requests are welcome on [GitHub](https://github.com/lostisl
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 
-[raise_error]:  https://lostisland.github.io/faraday/middleware/raise-error
+[raise_error]:  https://lostisland.github.io/faraday/#/middleware/included/raising-errors


### PR DESCRIPTION
Just found this when reading through the README. 😄 