### PR TITLE
Check for `Faraday::UploadIO` while rewinding

### DIFF
--- a/lib/faraday/retry/middleware.rb
+++ b/lib/faraday/retry/middleware.rb
@@ -209,11 +209,11 @@ module Faraday
       end
 
       def rewind_files(body)
-        return unless defined?(UploadIO)
+        return unless defined?(Faraday::UploadIO)
         return unless body.is_a?(Hash)
 
         body.each do |_, value|
-          value.rewind if value.is_a?(UploadIO)
+          value.rewind if value.is_a?(Faraday::UploadIO)
         end
       end
 


### PR DESCRIPTION
## Summary

We're currently checking for `defined?(UploadIO)`, which in the absence of the `faraday-multipart` will point to the now deprecated constant defined in `multipart-post`. With this change, we'll now explicitly check for `Faraday::UploadIO` which automatically points to the right constant based on the version of `multipart-post` in use.

Fixes #36