### PR TITLE
Relax `required_ruby_version` to support Ruby 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
+          - '4.0'
     steps:
     - uses: actions/checkout@v6
     - name: Set up Ruby

--- a/faraday-retry.gemspec
+++ b/faraday-retry.gemspec
@@ -28,11 +28,10 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'README.md', 'LICENSE.md', 'CHANGELOG.md']
 
-  spec.required_ruby_version = '>= 2.6', '< 4'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_runtime_dependency 'faraday', '~> 2.0'
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.21.0'


### PR DESCRIPTION
This Pull Request relaxed the `required_ruby_version` to allow Ruby 4.0.

The current gemspec specifies an upper bound of "< 4.0", which prevents `gem install faraday-retry` from working on Ruby 4.0, scheduled for release on December 25. By removing this upper bound, the gem will continue to work on Ruby 4.0 and future Ruby versions.

- Ruby 4.0.0 preview3 Released
  - https://www.ruby-lang.org/en/news/2025/12/18/ruby-4-0-0-preview3-released/

### Bundler version for development / test environments
This Pull Request removes the development dependency on the bundler gem.
In Ruby 4.0, Bundler is provided as a default gem with version 4.0 or later.

https://github.com/lostisland/faraday-retry/blob/611150171d8075cdd3e61662c16847dac1438d7e/faraday-retry.gemspec#L35
