### PR TITLE
Relax required_ruby_version to support Ruby 4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         ## Due to https://github.com/actions/runner/issues/849,
         ## we have to use quotes for '3.0'
-        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ group :test do
   gem 'faraday', '>= 1.0'
   gem 'faraday-multipart', '~> 1.0'
 
-  gem 'bundler', '~> 2.0'
   gem 'rake', '~> 13.0'
   gem 'rspec', '~> 3.0'
   gem 'simplecov', '~> 0.18.0'

--- a/faraday-retry.gemspec
+++ b/faraday-retry.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'README.md', 'LICENSE.md', 'CHANGELOG.md']
 
-  spec.required_ruby_version = '>= 2.4', '< 4'
+  spec.required_ruby_version = '>= 2.4'
 end


### PR DESCRIPTION
Relaxes `required_ruby_version` for the `1.x` branch. Analogous to #51 

- Removes the `< 4` limitation from gemspec
- Adds newer Ruby versions to the rspec matrix.
- Removes `bundler` dependency to use bundler version shipped with Ruby

Once this is released it should solve faraday >= 1.9.0 not being installable when using Ruby 4.0 (see https://github.com/fastlane/fastlane/issues/29874#issuecomment-3944771755)